### PR TITLE
Fix isomorphic-git import path for worker build

### DIFF
--- a/worker/git-local.js
+++ b/worker/git-local.js
@@ -5,7 +5,7 @@
  */
 
 import * as git from 'isomorphic-git';
-import http from 'isomorphic-git/http/web/index.js';
+import http from 'isomorphic-git/http/web';
 import * as fs from 'node:fs';
 
 /**


### PR DESCRIPTION
Fixes the module resolution error in the worker build by correcting the import path for isomorphic-git's HTTP web module.

Changed the import from `isomorphic-git/http/web/index.js` to `isomorphic-git/http/web` to match the package's exports configuration. This resolves the build failure when deploying to Cloudflare Workers.