### PR TITLE
Use OAuth only for auth, add repo scope for private repos

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,12 +35,10 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: deploy --define BUILD_TIMESTAMP:${{ steps.timestamp.outputs.BUILD_TIMESTAMP }}
           secrets: |
-            GITHUB_TOKEN
             GITHUB_CLIENT_ID
             GITHUB_CLIENT_SECRET
             APP_URL
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_API_TOKEN }}
           GITHUB_CLIENT_ID: ${{ secrets.G_CLIENT_ID }}
           GITHUB_CLIENT_SECRET: ${{ secrets.G_CLIENT_SECRET }}
           APP_URL: ${{ secrets.APP_URL }}

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -128,7 +128,6 @@ See `OAUTH_SETUP.md` for detailed instructions.
 ### For Administrators
 
 - Must configure OAuth before deploying
-- Existing `GITHUB_TOKEN` environment variable still supported
 - No database migration required
 
 ## Rollback Plan

--- a/OAUTH_SETUP.md
+++ b/OAUTH_SETUP.md
@@ -123,14 +123,13 @@ APP_URL=http://localhost:8787
 2. Use Cloudflare Secrets for production (`wrangler secret put`)
 3. Use `.dev.vars` file for local development (add to `.gitignore`)
 4. Regularly rotate your OAuth secrets
-5. Only request the minimum required OAuth scopes (currently `read:user`)
+5. OAuth scopes used: `read:user` (profile info) and `repo` (access to private repositories)
 
 ## Additional Configuration
 
 ### Optional Environment Variables
 
 - `OAUTH_REDIRECT_URI`: Override the default callback URL if needed
-- `GITHUB_TOKEN`: Fallback token for unauthenticated requests (useful for CI/CD)
 
 ### Updating Secrets
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ A beautiful web application that creates a "Spotify Wrapped" style visualization
 - 🎨 Beautiful, responsive UI with animations
 - 📱 Mobile-friendly design
 - 🌿 Retrieves commits from default branch (main/master) only
-- 🔐 Environment variable support for GitHub token (GITHUB_TOKEN)
 
 **What You'll See:**
 - Total commits, pull requests, issues, and code reviews
@@ -121,14 +120,6 @@ The app now supports GitHub OAuth login for a seamless experience:
 
    📖 **For detailed OAuth setup instructions, see [OAUTH_SETUP.md](./OAUTH_SETUP.md)**
 
-**For GitHub Actions / Automated Deployment:**
-
-The GitHub token is automatically configured during deployment:
-- When deploying via GitHub Actions, add `GH_API_TOKEN` secret to your repository
-- The deployment workflow automatically passes this as `GITHUB_TOKEN` to the Cloudflare Worker
-- This enables the worker to make authenticated API requests without rate limits
-- See the [Setup GitHub Actions Deployment](#setup-github-actions-deployment) section for configuration details
-
 ## Deployment
 
 ### Local Testing with Wrangler (Recommended Before Deployment)
@@ -169,14 +160,10 @@ The Cloudflare Worker:
    - Add the following secrets:
      - `CLOUDFLARE_API_TOKEN`: Your Cloudflare API token
      - `CLOUDFLARE_ACCOUNT_ID`: Your Cloudflare account ID
-     - `GH_API_TOKEN` (optional): Your GitHub Personal Access Token with `repo` scope
-       - This token will be automatically passed to the Cloudflare Worker as `GITHUB_TOKEN`
-       - Used to avoid GitHub API rate limits when fetching commit data
-       - Without this, the worker will use unauthenticated requests (limited to 60 requests/hour)
-     - `G_CLIENT_ID`: Your GitHub OAuth App Client ID (for OAuth login feature)
-     - `G_CLIENT_SECRET`: Your GitHub OAuth App Client Secret (for OAuth login feature)
+     - `G_CLIENT_ID`: Your GitHub OAuth App Client ID (required for OAuth login)
+     - `G_CLIENT_SECRET`: Your GitHub OAuth App Client Secret (required for OAuth login)
      - `APP_URL`: Your deployed app URL (e.g., `https://github-wrapped.your-subdomain.workers.dev`)
-   
+
    > **Note**: GitHub Actions doesn't allow secrets starting with `GITHUB_`, so OAuth secrets use `G_CLIENT_ID` and `G_CLIENT_SECRET`.
 
 3. **Deploy:**
@@ -316,17 +303,12 @@ Gets the current authenticated user's information.
 Fetches GitHub wrapped data for a user.
 
 **Query Parameters:**
-- `username` (required): GitHub username or organization
+- `username` (optional): GitHub username or organization (auto-detected from OAuth session if not provided)
 - `year` (optional): Year to generate wrapped for (default: 2025)
-- `token` (optional): GitHub API token for private repo access (deprecated, use OAuth login instead)
 
 **Authentication:**
-- If user is authenticated via OAuth, their token is automatically used
-- Fallback to environment variable `GITHUB_TOKEN` if no user session exists
-- Query parameter `token` still supported for backward compatibility
-
-**Environment Variables:**
-- `GITHUB_TOKEN` (optional): GitHub API token set in Cloudflare Worker environment. Used when no token is provided in query parameters or session. This is useful for automated workflows and GitHub Actions.
+- Users must authenticate via GitHub OAuth to access private repositories
+- The OAuth token is stored securely in an HTTP-only session cookie
 
 **Implementation Details:**
 - **Branch Filtering**: Only retrieves commits from the default branch (main or master) of each repository

--- a/worker/git-local.js
+++ b/worker/git-local.js
@@ -5,7 +5,7 @@
  */
 
 import * as git from 'isomorphic-git';
-import http from 'isomorphic-git/http/web/index.js';
+import http from 'isomorphic-git/http/web';
 import * as fs from 'node:fs';
 
 /**


### PR DESCRIPTION
## Summary
- Remove `GITHUB_TOKEN` environment variable and token query parameter fallbacks
- Use GitHub OAuth exclusively for authentication (via session cookie)
- Add `repo` scope to OAuth to enable cloning private repositories
- Fix isomorphic-git import path that was breaking the worker build

## Changes
- **worker/index.js**: OAuth-only auth, added `repo` scope
- **deploy.yml**: Removed `GITHUB_TOKEN` secret
- **Docs**: Updated to reflect OAuth-only authentication

Users must now sign in via GitHub OAuth to access their repositories. The `repo` scope allows cloning both public and private repos.