### PR TITLE
Disable autocomplete on GitHub username input

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -35,6 +35,8 @@
                 type="text"
                 :placeholder="isAuthenticated ? 'Optional - defaults to your username' : 'GitHub username...'"
                 class="input-main"
+                autocomplete="off"
+                name="github-username-search"
               />
             </div>
 


### PR DESCRIPTION
## Summary
Prevent browsers from auto-completing the GitHub username field by adding `autocomplete="off"` and a unique name attribute.

## Test Plan
- Open the application
- Verify the username input field does not show browser autocomplete suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)